### PR TITLE
Question Pre-Screening

### DIFF
--- a/backend-e2e/src/main.rs
+++ b/backend-e2e/src/main.rs
@@ -163,6 +163,7 @@ async fn hide_question(event: String, secret: String, question_id: i64) {
     let body = shared::ModQuestion {
         answered: false,
         hide: true,
+        screened: false,
     };
 
     let res = reqwest::Client::new()

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -161,6 +161,8 @@ impl App {
             deleted: false,
             premium_order: None,
             questions: Vec::new(),
+            screening: Vec::new(),
+            do_screening: false,
             state: EventState {
                 state: States::Open,
             },

--- a/backend/src/eventsdb/types/conversion.rs
+++ b/backend/src/eventsdb/types/conversion.rs
@@ -110,10 +110,11 @@ pub fn attributes_to_event(value: &AttributeMap) -> Result<ApiEventInfo, super::
         .map_err(|_| Error::MalformedObject(ATTR_EVENT_INFO_DELETED.into()))?
         .to_owned();
 
-    let do_screening = value[ATTR_EVENT_INFO_DO_SCREENING]
-        .as_bool()
-        .map_err(|_| Error::MalformedObject(ATTR_EVENT_INFO_DO_SCREENING.into()))?
-        .to_owned();
+    let do_screening = value
+        .get(ATTR_EVENT_INFO_DO_SCREENING)
+        .and_then(|val| val.as_bool().ok())
+        .copied()
+        .unwrap_or_default();
 
     let premium_order = value
         .get(ATTR_EVENT_INFO_PREMIUM)

--- a/backend/src/eventsdb/types/mod.rs
+++ b/backend/src/eventsdb/types/mod.rs
@@ -23,6 +23,7 @@ pub struct ApiEventInfo {
     #[serde(rename = "lastEditUnix")]
     pub last_edit_unix: i64,
     pub questions: Vec<QuestionItem>,
+    #[serde(default)]
     pub do_screening: bool,
     pub state: EventState,
     pub premium_order: Option<String>,

--- a/backend/src/eventsdb/types/mod.rs
+++ b/backend/src/eventsdb/types/mod.rs
@@ -4,7 +4,7 @@ use crate::utils::timestamp_now;
 use aws_sdk_dynamodb::types::AttributeValue;
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
-use shared::{EventData, EventInfo, EventState, EventTokens, QuestionItem};
+use shared::{EventData, EventInfo, EventState, EventTokens, PrescreenQuestion, QuestionItem};
 use std::collections::HashMap;
 
 use self::conversion::{attributes_to_event, event_to_attributes};
@@ -23,6 +23,8 @@ pub struct ApiEventInfo {
     #[serde(rename = "lastEditUnix")]
     pub last_edit_unix: i64,
     pub questions: Vec<QuestionItem>,
+    pub screening: Vec<PrescreenQuestion>,
+    pub do_screening: bool,
     pub state: EventState,
     pub premium_order: Option<String>,
     #[serde(default)]
@@ -73,6 +75,7 @@ impl From<ApiEventInfo> for EventInfo {
             deleted: val.deleted,
             last_edit_unix: val.last_edit_unix,
             questions: val.questions,
+            screening: val.screening,
             state: val.state,
             premium: val.premium_order.is_some(),
         }
@@ -192,6 +195,12 @@ mod test_serialization {
                     answered: true,
                     create_time_unix: 3,
                 }],
+                screening: vec![PrescreenQuestion {
+                    id: 1,
+                    text: String::from("q"),
+                    create_time_unix: 4,
+                }],
+                do_screening: true,
                 state: EventState {
                     state: States::Closed,
                 },
@@ -237,6 +246,8 @@ mod test_serialization {
                     answered: true,
                     create_time_unix: 3,
                 }],
+                screening: vec![],
+                do_screening: false,
                 state: EventState {
                     state: States::Closed,
                 },

--- a/backend/src/eventsdb/types/mod.rs
+++ b/backend/src/eventsdb/types/mod.rs
@@ -4,7 +4,7 @@ use crate::utils::timestamp_now;
 use aws_sdk_dynamodb::types::AttributeValue;
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
-use shared::{EventData, EventInfo, EventState, EventTokens, PrescreenQuestion, QuestionItem};
+use shared::{EventData, EventInfo, EventState, EventTokens, QuestionItem};
 use std::collections::HashMap;
 
 use self::conversion::{attributes_to_event, event_to_attributes};
@@ -23,7 +23,6 @@ pub struct ApiEventInfo {
     #[serde(rename = "lastEditUnix")]
     pub last_edit_unix: i64,
     pub questions: Vec<QuestionItem>,
-    pub screening: Vec<PrescreenQuestion>,
     pub do_screening: bool,
     pub state: EventState,
     pub premium_order: Option<String>,
@@ -75,8 +74,8 @@ impl From<ApiEventInfo> for EventInfo {
             deleted: val.deleted,
             last_edit_unix: val.last_edit_unix,
             questions: val.questions,
-            screening: val.screening,
             state: val.state,
+            screening: val.do_screening,
             premium: val.premium_order.is_some(),
         }
     }
@@ -193,12 +192,8 @@ mod test_serialization {
                     text: String::from("q"),
                     hidden: false,
                     answered: true,
+                    screened: true,
                     create_time_unix: 3,
-                }],
-                screening: vec![PrescreenQuestion {
-                    id: 1,
-                    text: String::from("q"),
-                    create_time_unix: 4,
                 }],
                 do_screening: true,
                 state: EventState {
@@ -244,9 +239,10 @@ mod test_serialization {
                     text: String::from("q"),
                     hidden: false,
                     answered: true,
+                    screened: false,
                     create_time_unix: 3,
                 }],
-                screening: vec![],
+
                 do_screening: false,
                 state: EventState {
                     state: States::Closed,

--- a/backend/src/handle.rs
+++ b/backend/src/handle.rs
@@ -189,12 +189,16 @@ pub async fn mod_edit_state(
 
 #[instrument(skip(app))]
 pub async fn mod_edit_screening(
-    Path((id, secret, screening)): Path<(String, String, bool)>,
+    Path((id, secret)): Path<(String, String)>,
     State(app): State<SharedApp>,
+    Json(payload): Json<shared::ModEditScreening>,
 ) -> std::result::Result<impl IntoResponse, InternalError> {
     tracing::info!("mod_edit_screening");
 
-    Ok(Json(app.edit_event_screening(id, secret, screening).await?))
+    Ok(Json(
+        app.edit_event_screening(id, secret, payload.screening)
+            .await?,
+    ))
 }
 
 #[instrument]

--- a/backend/src/handle.rs
+++ b/backend/src/handle.rs
@@ -187,6 +187,16 @@ pub async fn mod_edit_state(
     Ok(Json(app.edit_event_state(id, secret, payload.state).await?))
 }
 
+#[instrument(skip(app))]
+pub async fn mod_edit_screening(
+    Path((id, secret, screening)): Path<(String, String, bool)>,
+    State(app): State<SharedApp>,
+) -> std::result::Result<impl IntoResponse, InternalError> {
+    tracing::info!("mod_edit_screening");
+
+    Ok(Json(app.edit_event_screening(id, secret, screening).await?))
+}
+
 #[instrument]
 pub async fn ping_handler() -> Html<&'static str> {
     Html("pong")

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -261,7 +261,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .route("/delete/:id/:secret", get(handle::mod_delete_event))
         .route("/question/:id/:secret/:question_id", get(handle::mod_get_question))
         .route("/questionmod/:id/:secret/:question_id", post(handle::mod_edit_question))
-        .route("/screening/:id/:secret/:screening", post(handle::mod_edit_screening))
+        .route("/screening/:id/:secret", post(handle::mod_edit_screening))
         .route("/state/:id/:secret", post(handle::mod_edit_state));
 
     #[rustfmt::skip]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -261,6 +261,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .route("/delete/:id/:secret", get(handle::mod_delete_event))
         .route("/question/:id/:secret/:question_id", get(handle::mod_get_question))
         .route("/questionmod/:id/:secret/:question_id", post(handle::mod_edit_question))
+        .route("/screening/:id/:secret/:screening", post(handle::mod_edit_screening))
         .route("/state/:id/:secret", post(handle::mod_edit_state));
 
     #[rustfmt::skip]

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -53,7 +53,10 @@ features = [
     "Headers",
     "DomTokenList",
     "HtmlSelectElement",
-    "HtmlAnchorElement"]
+    "HtmlAnchorElement",
+    "ScrollIntoViewOptions",
+    "ScrollLogicalPosition",
+    "ScrollBehavior"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"

--- a/frontend/scss/event.scss
+++ b/frontend/scss/event.scss
@@ -330,6 +330,32 @@
 
     margin-left: 30px;
   }
+
+  .premium {
+    border: 1px solid #e9e9e9;
+    border-radius: 4px;
+    margin: 5px;
+    padding: 7px;
+
+    .title {
+      color: white;
+    }
+
+    .screening-option {
+      display: inline;
+      color: black;
+      border: 1px solid #e9e9e9;
+      border-radius: 4px;
+      box-shadow: 0px 2px 4px 0 rgba(0, 0, 0, 0.2);
+      background-color: white;
+      padding-left: 5px;
+      padding-right: 41px;
+      padding-top: 8px;
+      padding-bottom: 8px;
+      letter-spacing: 0.21875px;
+      font-size: 16px;
+    }
+  }
 }
 
 #ico-offline {

--- a/frontend/scss/question-card.scss
+++ b/frontend/scss/question-card.scss
@@ -38,6 +38,11 @@
   }
 }
 
+.unscreened-question {
+  background: lightgray;
+  border-color: lightgray;
+}
+
 .questionanchor {
   height: 100%;
   width: 100%;

--- a/frontend/src/components/question.rs
+++ b/frontend/src/components/question.rs
@@ -161,7 +161,6 @@ impl Component for Question {
         }
 
         if first_render && self.data.is_new {
-            // log::info!("scroll to: {} ({}), ", self.data.item.id, element_y);
             elem.scroll_into_view_with_scroll_into_view_options(
                 ScrollIntoViewOptions::new()
                     .block(ScrollLogicalPosition::Center)

--- a/frontend/src/components/question.rs
+++ b/frontend/src/components/question.rs
@@ -34,6 +34,7 @@ pub struct Props {
 
 pub struct Question {
     data: Props,
+    age_text: String,
     node_ref: NodeRef,
     last_pos: Option<i64>,
     timeout: Option<Timeout>,
@@ -62,6 +63,7 @@ impl Component for Question {
 
         Self {
             data: ctx.props().clone(),
+            age_text: String::new(),
             node_ref: NodeRef::default(),
             last_pos: None,
             timeout: None,
@@ -104,7 +106,14 @@ impl Component for Question {
                     .emit((self.data.item.id, QuestionClickType::Approve));
                 true
             }
-            Msg::UpdateAge => self.animation_time.is_none(),
+            Msg::UpdateAge => {
+                let age = self.get_age();
+                if age != self.age_text {
+                    self.age_text = age;
+                    return true;
+                }
+                false
+            }
             Msg::EndAnimation => {
                 self.animation_time = None;
                 false

--- a/frontend/src/components/question.rs
+++ b/frontend/src/components/question.rs
@@ -9,6 +9,8 @@ use web_sys::Element;
 use web_sys::HtmlElement;
 use yew::prelude::*;
 
+use crate::not;
+
 pub enum QuestionClickType {
     Like,
     Hide,
@@ -71,7 +73,11 @@ impl Component for Question {
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Like => {
-                if ctx.props().can_vote && !self.data.item.answered && !self.data.item.hidden {
+                if ctx.props().can_vote
+                    && self.data.item.screened
+                    && !self.data.item.answered
+                    && !self.data.item.hidden
+                {
                     ctx.props()
                         .on_click
                         .emit((self.data.item.id, QuestionClickType::Like));
@@ -169,9 +175,10 @@ impl Component for Question {
         let liked = ctx.props().local_like;
         let mod_view = ctx.props().mod_view;
         let blurred = ctx.props().blurr;
+        let can_vote = ctx.props().can_vote && self.data.item.screened;
 
         html! {
-            <div class="question-host questions-move"
+            <div class={classes!("question-host","questions-move",not(self.data.item.screened).then_some("unscreened-question"),)}
                 ref={self.node_ref.clone()}>
                 <a class="questionanchor" onclick={ctx.link().callback(|_| Msg::Like)}>
 
@@ -180,20 +187,23 @@ impl Component for Question {
                     </div>
 
                     {
-                        if liked {
-                            Self::get_bubble_liked(self.data.item.likes)
-                        }
-                        else
+                        if self.data.item.screened
                         {
-                            Self::get_bubble_not_liked(self.data.item.likes)
-                        }
+                            if liked {
+                                Self::get_bubble_liked(self.data.item.likes)
+                            }
+                            else
+                            {
+                                Self::get_bubble_not_liked(self.data.item.likes)
+                            }
+                        } else { html!() }
                     }
 
                     <div class={classes!("text",self.data.item.answered.then_some("answered"),blurred.then_some("blurr"))}>
                         {&self.data.item.text}
                     </div>
 
-                    {self.view_like(ctx.props().can_vote,liked,mod_view)}
+                    {self.view_like(can_vote,liked,mod_view)}
 
                     {self.view_checkmark(mod_view)}
                 </a>

--- a/frontend/src/components/question.rs
+++ b/frontend/src/components/question.rs
@@ -13,6 +13,7 @@ pub enum QuestionClickType {
     Like,
     Hide,
     Answer,
+    Approve,
 }
 
 //TODO: use bitflag to rid us of this warning
@@ -42,6 +43,7 @@ pub enum Msg {
     Like,
     ToggleHide,
     ToggleAnswered,
+    Approve,
     /// used to start the reorder animation
     StartAnimation,
     EndAnimation,
@@ -88,6 +90,12 @@ impl Component for Question {
                 ctx.props()
                     .on_click
                     .emit((self.data.item.id, QuestionClickType::Answer));
+                true
+            }
+            Msg::Approve => {
+                ctx.props()
+                    .on_click
+                    .emit((self.data.item.id, QuestionClickType::Approve));
                 true
             }
             Msg::UpdateAge => self.animation_time.is_none(),
@@ -227,34 +235,52 @@ impl Question {
         let hidden = self.data.item.hidden;
         let answered = self.data.item.answered;
 
-        html! {
-            <div class="options">
-                <button class={classes!("button-hide",hidden.then_some("reverse"))}
-                    onclick={ctx.link().callback(|_| Msg::ToggleHide)}
-                    hidden={answered}
-                    >
-                    {
-                        if hidden {
-                            html!{"unhide"}
-                        }else{
-                            html!{"hide"}
+        if self.data.item.screened {
+            html! {
+                <div class="options">
+                    <button class={classes!("button-hide",hidden.then_some("reverse"))}
+                        onclick={ctx.link().callback(|_| Msg::ToggleHide)}
+                        hidden={answered}
+                        >
+                        {
+                            if hidden {
+                                html!{"unhide"}
+                            }else{
+                                html!{"hide"}
+                            }
                         }
-                    }
-                </button>
+                    </button>
 
-                <button class={classes!("button-answered",answered.then_some("reverse"))}
-                    onclick={ctx.link().callback(|_| Msg::ToggleAnswered)}
-                    hidden={hidden}
-                    >
-                    {
-                        if answered {
-                            html!{"not answered"}
-                        }else{
-                            html!{"answered"}
+                    <button class={classes!("button-answered",answered.then_some("reverse"))}
+                        onclick={ctx.link().callback(|_| Msg::ToggleAnswered)}
+                        hidden={hidden}
+                        >
+                        {
+                            if answered {
+                                html!{"not answered"}
+                            }else{
+                                html!{"answered"}
+                            }
                         }
-                    }
-                </button>
-            </div>
+                    </button>
+                </div>
+            }
+        } else {
+            html! {
+                <div class="options">
+                    <button class={classes!("button-hide",hidden.then_some("reverse"))}
+                        onclick={ctx.link().callback(|_| Msg::ToggleHide)}
+                        >
+                        {"hide"}
+                    </button>
+
+                    <button class="button-answered"
+                        onclick={ctx.link().callback(|_| Msg::Approve)}
+                        >
+                        {"approve"}
+                    </button>
+                </div>
+            }
         }
     }
 

--- a/frontend/src/components/question_popup.rs
+++ b/frontend/src/components/question_popup.rs
@@ -71,10 +71,10 @@ impl Component for QuestionPopup {
 
                 ctx.link().send_future(async move {
                     if let Ok(item) = fetch::add_question(BASE_API, event_id.clone(), text).await {
+                        LocalCache::set_like_state(&event_id, item.id, true);
                         if !item.screened {
                             LocalCache::add_unscreened_question(&event_id, &item);
                         }
-                        LocalCache::set_like_state(&event_id, item.id, true);
                         Msg::QuestionCreated(Some(item.id))
                     } else {
                         Msg::QuestionCreated(None)

--- a/frontend/src/components/question_popup.rs
+++ b/frontend/src/components/question_popup.rs
@@ -71,6 +71,9 @@ impl Component for QuestionPopup {
 
                 ctx.link().send_future(async move {
                     if let Ok(item) = fetch::add_question(BASE_API, event_id.clone(), text).await {
+                        if !item.screened {
+                            LocalCache::add_unscreened_question(&event_id, &item);
+                        }
                         LocalCache::set_like_state(&event_id, item.id, true);
                         Msg::QuestionCreated(Some(item.id))
                     } else {

--- a/frontend/src/components/upgrade.rs
+++ b/frontend/src/components/upgrade.rs
@@ -101,7 +101,7 @@ impl Upgrade {
                     <li>{"Live Stats (participants, likes ..)"}</li>
                     <li>{"Export Data"}</li>
                     <li>{"Word Cloud"}</li>
-                    <li class="tbd">{"Prescreen Questions (coming soon..)"}</li>
+                    <li>{"Prescreen Questions"}</li>
                     <li class="tbd">{"Answer Questions (coming soon..)"}</li>
                 </ul>
                 </div>

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -54,7 +54,7 @@ use crate::{
     pages::{Event, Home, NewEvent, Print, Privacy},
 };
 
-pub const VERSION_STR: &str = "2.2.1";
+pub const VERSION_STR: &str = "2.3.0";
 
 #[derive(Default, Clone, Eq, PartialEq, Store)]
 pub struct State {

--- a/frontend/src/local_cache.rs
+++ b/frontend/src/local_cache.rs
@@ -1,37 +1,54 @@
 use gloo_storage::{LocalStorage, Storage};
 use serde::{Deserialize, Serialize};
+use shared::QuestionItem;
 use std::collections::HashSet;
 use wasm_bindgen::UnwrapThrowExt;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 struct EventStore {
     likes: HashSet<i64>,
+    unscreened: Vec<QuestionItem>,
 }
 
 pub struct LocalCache;
 
 impl LocalCache {
     pub fn is_liked(event: &str, id: i64) -> bool {
-        Self::get_state(event).contains(&id)
+        Self::get_state(event).likes.contains(&id)
     }
 
     pub fn set_like_state(event: &str, id: i64, like: bool) {
         let mut store = Self::get_state(event);
         if like {
-            store.insert(id);
+            store.likes.insert(id);
         } else {
-            store.remove(&id);
+            store.likes.remove(&id);
         }
         Self::set_state(event, store);
     }
 
-    fn get_state(event: &str) -> HashSet<i64> {
-        LocalStorage::get(event)
-            .map(|state: EventStore| state.likes)
-            .unwrap_or_default()
+    pub fn add_unscreened_question(event: &str, q: &QuestionItem) {
+        log::info!("question pending review: {}", q.id);
+        let mut store = Self::get_state(event);
+        store.unscreened.push(q.clone());
+        Self::set_state(event, store);
     }
 
-    fn set_state(event: &str, likes: HashSet<i64>) {
-        LocalStorage::set(event, EventStore { likes }).unwrap_throw();
+    // pub fn remove_unscreened_question(event: &str, id: i64) {
+    //     let mut store = Self::get_state(event);
+    //     store.unscreened.retain(|q| q.id != id);
+    //     Self::set_state(event, store);
+    // }
+
+    pub fn unscreened_questions(event: &str) -> Vec<QuestionItem> {
+        Self::get_state(event).unscreened
+    }
+
+    fn get_state(event: &str) -> EventStore {
+        LocalStorage::get(event).unwrap_or_default()
+    }
+
+    fn set_state(event: &str, data: EventStore) {
+        LocalStorage::set(event, data).unwrap_throw();
     }
 }

--- a/frontend/src/pages/event.rs
+++ b/frontend/src/pages/event.rs
@@ -585,6 +585,10 @@ impl Event {
         })
     }
 
+    const fn is_mod(&self) -> bool {
+        matches!(self.mode, Mode::Moderator)
+    }
+
     fn view_questions(&self, ctx: &Context<Self>, e: &GetEventResponse) -> Html {
         if e.info.questions.is_empty() {
             let no_questions_classes = classes!(match self.mode {
@@ -599,9 +603,10 @@ impl Event {
             }
         } else {
             let can_vote = !e.is_closed();
+            let is_mod = self.is_mod();
             html! {
                 <>
-                    {self.view_items(ctx,&self.unscreened,"Screening",can_vote)}
+                    {self.view_items(ctx,&self.unscreened,if is_mod {"For review"} else {"Questions currently in review by host"},can_vote)}
                     {self.view_items(ctx,&self.unanswered,"Hot Questions",can_vote)}
                     {self.view_items(ctx,&self.answered,"Answered",can_vote)}
                     {self.view_items(ctx,&self.hidden,"Hidden",can_vote)}

--- a/frontend/src/pages/event.rs
+++ b/frontend/src/pages/event.rs
@@ -867,6 +867,10 @@ impl Event {
             let mut questions = e.info.questions.clone();
             questions.sort_by(|a, b| b.likes.cmp(&a.likes));
 
+            let local_unscreened = LocalCache::unscreened_questions(&e.info.tokens.public_token);
+
+            questions.extend(local_unscreened.into_iter());
+
             let (unscreened, screened) = questions.into_iter().map(Rc::new).split(|i| i.screened);
             let (not_hidden, hidden) = screened.into_iter().split(|i| i.hidden);
             let (unanswered, answered) = not_hidden.into_iter().split(|i| i.answered);

--- a/frontend/src/pages/event.rs
+++ b/frontend/src/pages/event.rs
@@ -871,7 +871,8 @@ impl Event {
             let mut questions = e.info.questions.clone();
             questions.sort_by(|a, b| b.likes.cmp(&a.likes));
 
-            let local_unscreened = LocalCache::unscreened_questions(&e.info.tokens.public_token);
+            let local_unscreened =
+                LocalCache::unscreened_questions(&e.info.tokens.public_token, &questions);
 
             questions.extend(local_unscreened.into_iter());
 

--- a/frontend/src/pages/event.rs
+++ b/frontend/src/pages/event.rs
@@ -302,6 +302,7 @@ fn request_toggle_answered(
     });
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn request_approve_question(
     event: String,
     secret: String,

--- a/frontend/src/pages/event.rs
+++ b/frontend/src/pages/event.rs
@@ -710,7 +710,7 @@ impl Event {
 
                 {
                     if self.is_premium() {
-                        self.mod_view_premium(ctx,e)
+                        Self::mod_view_premium(ctx,e)
                     }else {html!{}}
                 }
 
@@ -732,7 +732,7 @@ impl Event {
         }
     }
 
-    fn mod_view_premium(&self, ctx: &Context<Self>, e: &GetEventResponse) -> Html {
+    fn mod_view_premium(ctx: &Context<Self>, e: &GetEventResponse) -> Html {
         html! {
             <div class="premium">
                 <div class="title">

--- a/frontend/src/pages/event.rs
+++ b/frontend/src/pages/event.rs
@@ -794,10 +794,9 @@ impl Event {
     fn mod_view_screening(ctx: &Context<Self>, e: &GetEventResponse) -> Html {
         if e.info.premium {
             html! {
-                <div class="deadline">
-                    <div class="linkbox-copy" onclick={ctx.link().callback(|_| Msg::ModEditScreening)}>
-                    {"screening"}
-                    </div>
+                <div class="deadline" onclick={ctx.link().callback(|_| Msg::ModEditScreening)}>
+                    <input type="checkbox" id="vehicle1" name="vehicle1" checked={e.info.screening} />
+                    {"Screening"}
                 </div>
             }
         } else {

--- a/frontend/src/pages/event.rs
+++ b/frontend/src/pages/event.rs
@@ -874,7 +874,7 @@ impl Event {
             let local_unscreened =
                 LocalCache::unscreened_questions(&e.info.tokens.public_token, &questions);
 
-            questions.extend(local_unscreened.into_iter());
+            questions.extend(local_unscreened);
 
             let (unscreened, screened) = questions.into_iter().map(Rc::new).split(|i| i.screened);
             let (not_hidden, hidden) = screened.into_iter().split(|i| i.hidden);

--- a/frontend/src/pages/event.rs
+++ b/frontend/src/pages/event.rs
@@ -71,6 +71,7 @@ pub struct Event {
     unanswered: Vec<Rc<QuestionItem>>,
     answered: Vec<Rc<QuestionItem>>,
     hidden: Vec<Rc<QuestionItem>>,
+    unscreened: Vec<Rc<QuestionItem>>,
     loading_state: LoadingState,
     dispatch: Dispatch<State>,
     socket_agent: Box<dyn Bridge<WebSocketAgent>>,
@@ -90,6 +91,7 @@ pub enum Msg {
     ModStateChange(yew::Event),
     StateChanged,
     CopyLink,
+    ModEditScreening,
     GlobalEvent(GlobalEvent),
     WordCloud(WordCloudOutput),
 }
@@ -131,6 +133,7 @@ impl Component for Event {
             unanswered: Vec::new(),
             answered: Vec::new(),
             hidden: Vec::new(),
+            unscreened: Vec::new(),
             dispatch: Dispatch::<State>::subscribe(Callback::noop()),
             socket_agent: ws,
             events: EventAgent::bridge(ctx.link().callback(Msg::GlobalEvent)),
@@ -171,6 +174,20 @@ impl Component for Event {
                     self.event_id.clone(),
                     ctx.props().secret.clone(),
                     new_state,
+                    ctx.link(),
+                );
+
+                false
+            }
+            Msg::ModEditScreening => {
+                request_screening_change(
+                    self.event_id.clone(),
+                    ctx.props().secret.clone(),
+                    self.state
+                        .event
+                        .as_ref()
+                        .map(|e| !e.info.screening)
+                        .unwrap_or_default(),
                     ctx.link(),
                 );
 
@@ -253,6 +270,7 @@ fn request_toggle_hide(
         let modify = ModQuestion {
             hide: !item.hidden,
             answered: item.answered,
+            screened: item.screened,
         };
         if let Err(res) = fetch::mod_question(BASE_API, event, secret, item.id, modify).await {
             log::error!("hide error: {}", res);
@@ -273,6 +291,28 @@ fn request_toggle_answered(
         let modify = ModQuestion {
             hide: item.hidden,
             answered: !item.answered,
+            screened: item.screened,
+        };
+
+        if let Err(e) = fetch::mod_question(BASE_API, event, secret, item.id, modify).await {
+            log::error!("mod_questio error: {e}");
+        }
+
+        Msg::QuestionUpdated(item.id)
+    });
+}
+
+fn request_approve_question(
+    event: String,
+    secret: String,
+    item: QuestionItem,
+    link: &html::Scope<Event>,
+) {
+    link.send_future(async move {
+        let modify = ModQuestion {
+            hide: false,
+            answered: false,
+            screened: true,
         };
 
         if let Err(e) = fetch::mod_question(BASE_API, event, secret, item.id, modify).await {
@@ -321,6 +361,23 @@ fn request_state_change(
     link.send_future(async move {
         if let Err(e) = fetch::mod_state_change(BASE_API, id, secret.unwrap_throw(), state).await {
             log::error!("mod_state_change error: {e}");
+        }
+
+        Msg::StateChanged
+    });
+}
+
+fn request_screening_change(
+    id: String,
+    secret: Option<String>,
+    screening: bool,
+    link: &html::Scope<Event>,
+) {
+    link.send_future(async move {
+        if let Err(e) =
+            fetch::mod_edit_screening(BASE_API, id, secret.unwrap_throw(), screening).await
+        {
+            log::error!("mod_edit_screening error: {e}");
         }
 
         Msg::StateChanged
@@ -543,6 +600,7 @@ impl Event {
             let can_vote = !e.is_closed();
             html! {
                 <>
+                    {self.view_items(ctx,&self.unscreened,"Screening",can_vote)}
                     {self.view_items(ctx,&self.unanswered,"Hot Questions",can_vote)}
                     {self.view_items(ctx,&self.answered,"Answered",can_vote)}
                     {self.view_items(ctx,&self.hidden,"Hidden",can_vote)}
@@ -657,6 +715,7 @@ impl Event {
             }
 
             {Self::mod_view_deadline(e)}
+            {Self::mod_view_screening(ctx,e)}
 
             </>
             }
@@ -731,6 +790,20 @@ impl Event {
         }
     }
 
+    fn mod_view_screening(ctx: &Context<Self>, e: &GetEventResponse) -> Html {
+        if e.info.premium {
+            html! {
+                <div class="deadline">
+                    <div class="linkbox-copy" onclick={ctx.link().callback(|_| Msg::ModEditScreening)}>
+                    {"screening"}
+                    </div>
+                </div>
+            }
+        } else {
+            html! {}
+        }
+    }
+
     fn mod_urls(&self, ctx: &Context<Self>) -> Html {
         if matches!(self.mode, Mode::Moderator) {
             html! {
@@ -793,10 +866,11 @@ impl Event {
             let mut questions = e.info.questions.clone();
             questions.sort_by(|a, b| b.likes.cmp(&a.likes));
 
-            let (not_hidden, hidden) = questions.into_iter().map(Rc::new).split(|i| i.hidden);
-
+            let (unscreened, screened) = questions.into_iter().map(Rc::new).split(|i| i.screened);
+            let (not_hidden, hidden) = screened.into_iter().split(|i| i.hidden);
             let (unanswered, answered) = not_hidden.into_iter().split(|i| i.answered);
 
+            self.unscreened = unscreened.collect();
             self.answered = answered.collect();
             self.unanswered = unanswered.collect();
             self.hidden = hidden.collect();
@@ -864,6 +938,16 @@ impl Event {
             QuestionClickType::Answer => {
                 if let Some(q) = self.state.event.as_ref().unwrap_throw().get_question(id) {
                     request_toggle_answered(
+                        self.event_id.clone(),
+                        ctx.props().secret.clone().unwrap_throw(),
+                        q,
+                        ctx.link(),
+                    );
+                }
+            }
+            QuestionClickType::Approve => {
+                if let Some(q) = self.state.event.as_ref().unwrap_throw().get_question(id) {
+                    request_approve_question(
                         self.event_id.clone(),
                         ctx.props().secret.clone().unwrap_throw(),
                         q,

--- a/frontend/src/pages/event.rs
+++ b/frontend/src/pages/event.rs
@@ -709,8 +709,11 @@ impl Event {
                 </button>
 
                 {
-                    self.mod_view_export(ctx)
+                    if self.is_premium() {
+                        self.mod_view_premium(ctx,e)
+                    }else {html!{}}
                 }
+
 
             </div>
 
@@ -721,7 +724,6 @@ impl Event {
             }
 
             {Self::mod_view_deadline(e)}
-            {Self::mod_view_screening(ctx,e)}
 
             </>
             }
@@ -730,15 +732,20 @@ impl Event {
         }
     }
 
-    fn mod_view_export(&self, ctx: &Context<Self>) -> Html {
-        if self.is_premium() {
-            html! {
+    fn mod_view_premium(&self, ctx: &Context<Self>, e: &GetEventResponse) -> Html {
+        html! {
+            <div class="premium">
+                <div class="title">
+                    {"This is a premium event"}
+                </div>
+                <div class="screening-option" onclick={ctx.link().callback(|_| Msg::ModEditScreening)}>
+                    <input type="checkbox" id="vehicle1" name="vehicle1" checked={e.info.screening} />
+                    {"Screening"}
+                </div>
                 <button class="button-white" onclick={ctx.link().callback(|_|Msg::ModExport)} >
                     {"Export"}
                 </button>
-            }
-        } else {
-            html! {}
+            </div>
         }
     }
 
@@ -793,19 +800,6 @@ impl Event {
                 {". Please upgrade to premium to make it permanent."}
                 </div>
             }
-        }
-    }
-
-    fn mod_view_screening(ctx: &Context<Self>, e: &GetEventResponse) -> Html {
-        if e.info.premium {
-            html! {
-                <div class="deadline" onclick={ctx.link().callback(|_| Msg::ModEditScreening)}>
-                    <input type="checkbox" id="vehicle1" name="vehicle1" checked={e.info.screening} />
-                    {"Screening"}
-                </div>
-            }
-        } else {
-            html! {}
         }
     }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -36,6 +36,13 @@ pub struct QuestionItem {
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
+pub struct PrescreenQuestion {
+    pub id: i64,
+    pub text: String,
+    pub create_time_unix: i64,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 pub struct EventUpgrade {
     pub url: String,
 }
@@ -57,6 +64,7 @@ pub struct EventInfo {
     #[serde(rename = "lastEditUnix")]
     pub last_edit_unix: i64,
     pub questions: Vec<QuestionItem>,
+    pub screening: Vec<PrescreenQuestion>,
     pub state: EventState,
     #[serde(default)]
     pub premium: bool,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -31,6 +31,7 @@ pub struct QuestionItem {
     pub text: String,
     pub hidden: bool,
     pub answered: bool,
+    #[serde(default)]
     pub screened: bool,
     #[serde(rename = "createTimeUnix")]
     pub create_time_unix: i64,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -31,14 +31,8 @@ pub struct QuestionItem {
     pub text: String,
     pub hidden: bool,
     pub answered: bool,
+    pub screened: bool,
     #[serde(rename = "createTimeUnix")]
-    pub create_time_unix: i64,
-}
-
-#[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
-pub struct PrescreenQuestion {
-    pub id: i64,
-    pub text: String,
     pub create_time_unix: i64,
 }
 
@@ -64,10 +58,11 @@ pub struct EventInfo {
     #[serde(rename = "lastEditUnix")]
     pub last_edit_unix: i64,
     pub questions: Vec<QuestionItem>,
-    pub screening: Vec<PrescreenQuestion>,
     pub state: EventState,
     #[serde(default)]
     pub premium: bool,
+    #[serde(default)]
+    pub screening: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
@@ -123,6 +118,7 @@ pub struct AddQuestion {
 pub struct ModQuestion {
     pub hide: bool,
     pub answered: bool,
+    pub screened: bool,
 }
 
 ///

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -149,6 +149,11 @@ pub struct ModEventState {
     pub state: EventState,
 }
 
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ModEditScreening {
+    pub screening: bool,
+}
+
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub struct EventState {
     pub state: States,


### PR DESCRIPTION
- [x] BE: event flag to mark every new question as `unscreened` first
- [x] BE: new endpoint to mark a question as `screened`
- [x] FE: show unscreened questions and allow `approve` or `hide`
- [x] FE: new toggle to toggle `screening` feature in premium events
- [x] FE: client caches unscreened questions and shows them accordingly to client who created it
- [x] FE: scroll to newly created question

how to moderate unscreened questions:
<img width="719" alt="Screenshot 2023-07-21 at 15 23 09" src="https://github.com/liveask/liveask/assets/776816/1a06b8ba-29ee-49a2-aa31-25fd58fbb4ef">
