### PR TITLE
Adding Email Validation To Form

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
+name = "email_address"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2153bd83ebc09db15bcbdc3e2194d901804952e3dc96967e1cd3b0c5c32d112"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3598,6 +3607,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.4.2",
  "chrono",
+ "email_address",
  "serde",
  "serde_repr",
  "url",

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -1113,6 +1113,34 @@ mod test {
 
     #[tokio::test]
     #[tracing_test::traced_test]
+    async fn test_event_create_email_pass_validation() {
+        let app = App::new(
+            Arc::new(InMemoryEventsDB::default()),
+            Arc::new(PubSubInMemory::default()),
+            Arc::new(MockViewers::new()),
+            Arc::new(Payment::default()),
+            Tracking::default(),
+            String::new(),
+        );
+
+        let res = app
+            .create_event(AddEvent {
+                data: EventData {
+                    name: String::from("123456789"),
+                    description: String::from("123456789 123456789 123456789 !"),
+                    short_url: String::new(),
+                    long_url: None,
+                },
+                moderator_email: "testuser@live-ask.com",
+                test: false,
+            })
+            .await;
+
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
     async fn test_event_create() {
         let eventdb = Arc::new(InMemoryEventsDB::default());
         let app = App::new(
@@ -1126,7 +1154,7 @@ mod test {
 
         app.create_event(AddEvent {
             data: EventData {
-                name: String::from("123456789"),
+                name: TEST_V,
                 description: String::from("123456789 123456789 123456789 !"),
                 short_url: String::new(),
                 long_url: None,

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -160,7 +160,7 @@ impl App {
     #[instrument(skip(self, request))]
     pub async fn create_event(&self, request: AddEvent) -> Result<EventInfo> {
         let validation = shared::CreateEventValidation::default()
-            .check(&request.data.name, &request.data.description, request.moderator_email.unwrap_or_default().as_str());
+            .check(&request.data.name, &request.data.description, request.moderator_email.clone().unwrap_or_default().as_str());
 
         if validation.has_any() {
             return Err(InternalError::MetaValidation(shared::EditMetaData {
@@ -1098,12 +1098,12 @@ mod test {
         let res = app
             .create_event(AddEvent {
                 data: EventData {
-                    name: TEST_EVENT_NAME,
-                    description: TEST_EVENT_DESC,
+                    name: TEST_EVENT_NAME.to_string(),
+                    description: TEST_EVENT_DESC.to_string(),
                     short_url: String::new(),
                     long_url: None,
                 },
-                moderator_email: "a@a",
+                moderator_email: Option::Some("a@a".to_string()),
                 test: false,
             })
             .await;
@@ -1126,12 +1126,12 @@ mod test {
         let res = app
             .create_event(AddEvent {
                 data: EventData {
-                    name: TEST_EVENT_NAME,
-                    description: TEST_EVENT_DESC,
+                    name: TEST_EVENT_NAME.to_string(),
+                    description: TEST_EVENT_DESC.to_string(),
                     short_url: String::new(),
                     long_url: None,
                 },
-                moderator_email: "testuser@live-ask.com",
+                moderator_email: Option::Some("testuser@live-ask.com"),
                 test: false,
             })
             .await;
@@ -1154,7 +1154,7 @@ mod test {
 
         app.create_event(AddEvent {
             data: EventData {
-                name: TEST_V,
+                name: String::from("123456789"),
                 description: String::from("123456789 123456789 123456789 !"),
                 short_url: String::new(),
                 long_url: None,

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -1052,7 +1052,7 @@ mod test {
         viewers::MockViewers,
     };
     use pretty_assertions::{assert_eq, assert_ne};
-    use shared::{AddQuestion, CurrentTag, EventData, TagId, TEST_VALID_QUESTION};
+    use shared::{AddQuestion, CurrentTag, EventData, TagId, TEST_EVENT_DESC, TEST_EVENT_NAME, TEST_VALID_QUESTION};
     use std::sync::Arc;
 
     #[tokio::test]
@@ -1098,8 +1098,8 @@ mod test {
         let res = app
             .create_event(AddEvent {
                 data: EventData {
-                    name: String::from("123456789"),
-                    description: String::from("123456789 123456789 123456789 !"),
+                    name: TEST_EVENT_NAME,
+                    description: TEST_EVENT_DESC,
                     short_url: String::new(),
                     long_url: None,
                 },
@@ -1126,8 +1126,8 @@ mod test {
         let res = app
             .create_event(AddEvent {
                 data: EventData {
-                    name: String::from("123456789"),
-                    description: String::from("123456789 123456789 123456789 !"),
+                    name: TEST_EVENT_NAME,
+                    description: TEST_EVENT_DESC,
                     short_url: String::new(),
                     long_url: None,
                 },

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -1085,6 +1085,34 @@ mod test {
 
     #[tokio::test]
     #[tracing_test::traced_test]
+    async fn test_event_create_email_fail_validation() {
+        let app = App::new(
+            Arc::new(InMemoryEventsDB::default()),
+            Arc::new(PubSubInMemory::default()),
+            Arc::new(MockViewers::new()),
+            Arc::new(Payment::default()),
+            Tracking::default(),
+            String::new(),
+        );
+
+        let res = app
+            .create_event(AddEvent {
+                data: EventData {
+                    name: String::from("123456789"),
+                    description: String::from("123456789 123456789 123456789 !"),
+                    short_url: String::new(),
+                    long_url: None,
+                },
+                moderator_email: "a@a",
+                test: false,
+            })
+            .await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
     async fn test_event_create() {
         let eventdb = Arc::new(InMemoryEventsDB::default());
         let app = App::new(

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -160,7 +160,8 @@ impl App {
     #[instrument(skip(self, request))]
     pub async fn create_event(&self, request: AddEvent) -> Result<EventInfo> {
         let validation = shared::CreateEventValidation::default()
-            .check(&request.data.name, &request.data.description, "");
+            .check(&request.data.name, &request.data.description, request.moderator_email.unwrap_or_default().as_str());
+
         if validation.has_any() {
             return Err(InternalError::MetaValidation(shared::EditMetaData {
                 title: request.data.name.clone(),

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -1131,7 +1131,7 @@ mod test {
                     short_url: String::new(),
                     long_url: None,
                 },
-                moderator_email: Option::Some("testuser@live-ask.com"),
+                moderator_email: Option::Some("testuser@live-ask.com".to_string()),
                 test: false,
             })
             .await;

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -159,8 +159,11 @@ impl App {
 
     #[instrument(skip(self, request))]
     pub async fn create_event(&self, request: AddEvent) -> Result<EventInfo> {
-        let validation = shared::CreateEventValidation::default()
-            .check(&request.data.name, &request.data.description, request.moderator_email.clone().unwrap_or_default().as_str());
+        let validation = shared::CreateEventValidation::default().check(
+            &request.data.name,
+            &request.data.description,
+            request.moderator_email.clone().unwrap_or_default().as_str(),
+        );
 
         if validation.has_any() {
             return Err(InternalError::MetaValidation(shared::EditMetaData {
@@ -1052,7 +1055,10 @@ mod test {
         viewers::MockViewers,
     };
     use pretty_assertions::{assert_eq, assert_ne};
-    use shared::{AddQuestion, CurrentTag, EventData, TagId, TEST_EVENT_DESC, TEST_EVENT_NAME, TEST_VALID_QUESTION};
+    use shared::{
+        AddQuestion, CurrentTag, EventData, TagId, TEST_EVENT_DESC, TEST_EVENT_NAME,
+        TEST_VALID_QUESTION,
+    };
     use std::sync::Arc;
 
     #[tokio::test]

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -160,7 +160,7 @@ impl App {
     #[instrument(skip(self, request))]
     pub async fn create_event(&self, request: AddEvent) -> Result<EventInfo> {
         let validation = shared::CreateEventValidation::default()
-            .check(&request.data.name, &request.data.description);
+            .check(&request.data.name, &request.data.description, "");
         if validation.has_any() {
             return Err(InternalError::MetaValidation(shared::EditMetaData {
                 title: request.data.name.clone(),
@@ -998,7 +998,7 @@ impl App {
         }
 
         let validation =
-            shared::CreateEventValidation::default().check(&edit.title, &edit.description);
+            shared::CreateEventValidation::default().check(&edit.title, &edit.description, "");
         if validation.has_any() {
             return Err(InternalError::MetaValidation(edit.clone()));
         }

--- a/frontend/src/components/meta_popup.rs
+++ b/frontend/src/components/meta_popup.rs
@@ -54,7 +54,9 @@ impl Component for MetaPopup {
     fn changed(&mut self, ctx: &Context<Self>, _old_props: &Self::Properties) -> bool {
         if ctx.props().show {
             self.meta = ctx.props().meta.clone();
-            self.errors = self.errors.check(&self.meta.title, &self.meta.description);
+            self.errors = self
+                .errors
+                .check(&self.meta.title, &self.meta.description, "");
         }
 
         true
@@ -99,12 +101,16 @@ impl Component for MetaPopup {
                     Input::Title => {
                         let target: HtmlInputElement = c.target_dyn_into().unwrap_throw();
                         self.meta.title = target.value();
-                        self.errors = self.errors.check(&self.meta.title, &self.meta.description);
+                        self.errors =
+                            self.errors
+                                .check(&self.meta.title, &self.meta.description, "");
                     }
                     Input::Desc => {
                         let target: HtmlTextAreaElement = c.target_dyn_into().unwrap_throw();
                         self.meta.description = target.value();
-                        self.errors = self.errors.check(&self.meta.title, &self.meta.description);
+                        self.errors =
+                            self.errors
+                                .check(&self.meta.title, &self.meta.description, "");
                     }
                 };
                 true

--- a/frontend/src/pages/newevent.rs
+++ b/frontend/src/pages/newevent.rs
@@ -148,7 +148,7 @@ impl Component for NewEvent {
                             />
                         </div>
                         <div hidden={self.errors.email.is_none()} class="invalid">
-                            { Self::name_error(&self.errors.name).unwrap_or_default() }
+                            { Self::email_error(&self.errors.email).unwrap_or_default() }
                         </div>
                         <div class="input-box">
                             <TextArea

--- a/frontend/src/pages/newevent.rs
+++ b/frontend/src/pages/newevent.rs
@@ -94,17 +94,19 @@ impl Component for NewEvent {
                         let target: HtmlInputElement = c.target_dyn_into().unwrap_throw();
                         self.name = target.value();
 
-                        self.errors = self.errors.check(&self.name, &self.desc);
+                        self.errors = self.errors.check(&self.name, &self.desc, &self.email);
                     }
                     Input::Email => {
                         let target: HtmlInputElement = c.target_dyn_into().unwrap_throw();
                         self.email = target.value();
+
+                        self.errors = self.errors.check(&self.name, &self.desc, &self.email);
                     }
                     Input::Desc => {
                         let target: HtmlTextAreaElement = c.target_dyn_into().unwrap_throw();
                         self.desc = target.value();
 
-                        self.errors = self.errors.check(&self.name, &self.desc);
+                        self.errors = self.errors.check(&self.name, &self.desc, &self.email);
                     }
                 }
 
@@ -144,6 +146,9 @@ impl Component for NewEvent {
                                 maxlength="100"
                                 oninput={ctx.link().callback(|input| Msg::InputChange(Input::Email,input))}
                             />
+                        </div>
+                        <div hidden={self.errors.email.is_none()} class="invalid">
+                            { Self::name_error(&self.errors.name).unwrap_or_default() }
                         </div>
                         <div class="input-box">
                             <TextArea
@@ -205,7 +210,15 @@ impl NewEvent {
             Some(CreateEventError::MaxWords(_, max)) => {
                 Some(format!("Name must not contain more than {max} words."))
             }
+            Some(CreateEventError::InvalidEmail) => None,
             None => None,
+        }
+    }
+
+    pub fn email_error(state: &Option<CreateEventError>) -> Option<String> {
+        match state {
+            Some(CreateEventError::InvalidEmail) => Some("Invalid Email Provided".to_string()),
+            _ => None,
         }
     }
 }

--- a/frontend/src/pages/newevent.rs
+++ b/frontend/src/pages/newevent.rs
@@ -210,8 +210,7 @@ impl NewEvent {
             Some(CreateEventError::MaxWords(_, max)) => {
                 Some(format!("Name must not contain more than {max} words."))
             }
-            Some(CreateEventError::InvalidEmail) => None,
-            None => None,
+            Some(CreateEventError::InvalidEmail) | None => None,
         }
     }
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,6 +12,7 @@ bitflags = { version = "2.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_repr = "0.1"
 url = "2.5"
+email_address = "0.2.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 chrono = { version = "0.4", default-features = false, features = [

--- a/shared/src/validation/create_event.rs
+++ b/shared/src/validation/create_event.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 ///
 #[derive(Debug, Clone, Copy)]
 pub enum CreateEventError {
@@ -79,7 +81,7 @@ impl CreateEventValidation {
         let trimmed_len = v.trim().len();
 
         if trimmed_len > 0 {
-            if !email_address::EmailAddress::is_valid(v) {
+            if !email_address::EmailAddress::from_str(v).is_ok() {
                 Some(CreateEventError::InvalidEmail)
             } else {
                 None

--- a/shared/src/validation/create_event.rs
+++ b/shared/src/validation/create_event.rs
@@ -2,9 +2,11 @@
 #[derive(Debug, Clone, Copy)]
 pub enum CreateEventError {
     Empty,
+    InvalidEmail,
     MaxLength(usize, usize),
     MinLength(usize, usize),
     MaxWords(usize, usize),
+
 }
 
 const DESC_TRIMMED_MIN_LEN: usize = 30;
@@ -16,19 +18,21 @@ const NAME_TRIMMED_MAX_WORDS: usize = 13;
 pub struct CreateEventValidation {
     pub name: Option<CreateEventError>,
     pub desc: Option<CreateEventError>,
+    pub email: Option<CreateEventError>
 }
 
 impl CreateEventValidation {
     #[must_use]
-    pub fn check(mut self, name: &str, desc: &str) -> Self {
+    pub fn check(mut self, name: &str, desc: &str, email: &str) -> Self {
         self.name = Self::check_name(name);
         self.desc = Self::check_desc(desc);
+        self.email = Self::check_email(email);
         self
     }
 
     #[must_use]
     pub const fn has_any(&self) -> bool {
-        self.name.is_some() || self.desc.is_some()
+        self.name.is_some() || self.desc.is_some() || self.email.is_some()
     }
 
     fn check_name(v: &str) -> Option<CreateEventError> {
@@ -69,4 +73,21 @@ impl CreateEventValidation {
             None
         }
     }
+
+    #[must_use]
+    pub fn check_email(v: &str) -> Option<CreateEventError> {
+        let trimmed_len = v.trim().len();
+
+        if trimmed_len > 0 {
+            if !email_address::EmailAddress::is_valid(v) {
+                Some(CreateEventError::InvalidEmail)
+            } else {
+                None
+            }
+        }
+        else {
+            None
+        }
+    }
+
 }

--- a/shared/src/validation/create_event.rs
+++ b/shared/src/validation/create_event.rs
@@ -81,10 +81,16 @@ impl CreateEventValidation {
         let trimmed_len = v.trim().len();
 
         if trimmed_len > 0 {
-            if !email_address::EmailAddress::from_str(v).is_ok() {
+            let email = email_address::EmailAddress::from_str(v);
+            if !email.is_ok() {
                 Some(CreateEventError::InvalidEmail)
             } else {
-                None
+                if !email.ok().unwrap().domain().contains(".") {
+                    Some(CreateEventError::InvalidEmail)
+                }
+                else {
+                    None
+                }
             }
         }
         else {

--- a/shared/src/validation/create_event.rs
+++ b/shared/src/validation/create_event.rs
@@ -8,7 +8,6 @@ pub enum CreateEventError {
     MaxLength(usize, usize),
     MinLength(usize, usize),
     MaxWords(usize, usize),
-
 }
 
 const DESC_TRIMMED_MIN_LEN: usize = 30;
@@ -20,7 +19,7 @@ const NAME_TRIMMED_MAX_WORDS: usize = 13;
 pub struct CreateEventValidation {
     pub name: Option<CreateEventError>,
     pub desc: Option<CreateEventError>,
-    pub email: Option<CreateEventError>
+    pub email: Option<CreateEventError>,
 }
 
 impl CreateEventValidation {
@@ -82,20 +81,15 @@ impl CreateEventValidation {
 
         if trimmed_len > 0 {
             let email = email_address::EmailAddress::from_str(v);
-            if !email.is_ok() {
+            if email.is_err() {
                 Some(CreateEventError::InvalidEmail)
+            } else if email.ok()?.domain().contains('.') {
+                None
             } else {
-                if !email.ok().unwrap().domain().contains(".") {
-                    Some(CreateEventError::InvalidEmail)
-                }
-                else {
-                    None
-                }
+                Some(CreateEventError::InvalidEmail)
             }
-        }
-        else {
+        } else {
             None
         }
     }
-
 }


### PR DESCRIPTION
This Pull Request Closes #69 

Adds Email Validation to Event Creation Form using the email_address crate, I also added another check of a `.` in the domain to make sure that the email isn't just `a@a` as that was originally passing using just the crate, as visible in the image below.
![image](https://github.com/liveask/liveask/assets/113200622/49bd9e9d-8e0d-45b1-876b-c8b000a2b5fe)

Final version is visible below.
![image](https://github.com/liveask/liveask/assets/113200622/0d59555e-cd8e-4973-8eb1-fc9630d31220)

Could possibly add a mailbox existance checker later on.