### PR TITLE
backend: replace redis session admin auth with stateless JWT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
  "fastrand 2.1.1",
  "hex",
  "http 0.2.12",
- "ring 0.17.8",
+ "ring",
  "time",
  "tokio",
  "tracing",
@@ -725,29 +725,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum-login"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53380c8fe0c99b72463662d8a245e7706a40554bf9a08954f3e4c4249635a02"
-dependencies = [
- "async-trait",
- "axum",
- "axum-sessions",
- "base64 0.13.1",
- "dyn-clone",
- "futures",
- "percent-encoding",
- "ring 0.16.20",
- "secrecy",
- "serde",
- "serde_json",
- "tokio",
- "tower",
- "tower-http",
- "tracing",
 ]
 
 [[package]]
@@ -1300,12 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_builder"
@@ -1386,12 +1360,6 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "easy-cast"
@@ -2539,6 +2507,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "konst"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,7 +2594,6 @@ dependencies = [
  "aws-sdk-ses",
  "aws-smithy-http",
  "axum",
- "axum-login",
  "axum-prometheus",
  "axum-sessions",
  "axum-test",
@@ -2620,6 +2602,7 @@ dependencies = [
  "ezlime-rs",
  "futures-util",
  "handlebars",
+ "jsonwebtoken",
  "mime",
  "mockall",
  "posthog-core",
@@ -2843,10 +2826,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
+name = "num-bigint"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3000,6 +2993,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -3576,21 +3579,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -3599,8 +3587,8 @@ dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3645,7 +3633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-webpki",
  "sct",
 ]
@@ -3695,8 +3683,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3732,17 +3720,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "zeroize",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3899,10 +3878,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3918,10 +3898,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.210"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4084,6 +4073,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.17",
+ "time",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4153,12 +4154,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -4343,32 +4338,31 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4759,12 +4753,6 @@ name = "unicode-xid"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,13 +23,13 @@ aws-sdk-dynamodb = "1.2"
 aws-sdk-ses = "1.2"
 aws-smithy-http = "0.60"
 axum = { version = "0.6", features = ["ws"] }
-axum-login = "0.6"
 axum-prometheus = "0.4"
 axum-sessions = "0.5"
 chrono = { workspace = true }
 ezlime-rs = "0.2"
 futures-util = "0.3"
 handlebars = { workspace = true }
+jsonwebtoken = "9"
 posthog-core = { git = "https://github.com/rivet-gg/posthog-rs.git", rev = "fa4d39a" }
 rand = { version = "0.8", features = ["min_const_gen"] }
 reqwest = { version = "0.11", features = ["json"] }

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -16,11 +16,11 @@ use tracing::instrument;
 
 use crate::{env::admin_pwd_hash, error::InternalError};
 
-/// Cookie carrying the admin JWT. Verified statelessly on every request — no Redis lookup.
+/// Cookie carrying the admin JWT.
 const AUTH_COOKIE: &str = "auth";
 const ADMIN_NAME: &str = "admin";
 /// Token / cookie lifetime (was the session ttl).
-const COOKIE_TTL: Duration = Duration::from_secs(60 * 60 * 2);
+const COOKIE_TTL: Duration = Duration::from_hours(2);
 
 /// JWT signing key + cookie flags, shared via request extension so the handlers and the
 /// `OptionalUser` extractor can verify tokens without any session store.

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -20,7 +20,7 @@ use crate::{env::admin_pwd_hash, error::InternalError};
 const AUTH_COOKIE: &str = "auth";
 const ADMIN_NAME: &str = "admin";
 /// Token / cookie lifetime (was the session ttl).
-const COOKIE_TTL: Duration = Duration::from_hours(2);
+const COOKIE_TTL: Duration = Duration::from_secs(2 * 60 * 60);
 
 /// JWT signing key + cookie flags, shared via request extension so the handlers and the
 /// `OptionalUser` extractor can verify tokens without any session store.

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -1,170 +1,291 @@
+use std::{sync::Arc, time::Duration};
+
 use async_redis_session::RedisSessionStore;
 use async_trait::async_trait;
 use axum::{
-    Json,
+    Extension, Json,
     extract::FromRequestParts,
-    http::{StatusCode, request::Parts},
-    response::IntoResponse,
+    http::{HeaderMap, header, request::Parts},
+    response::{AppendHeaders, IntoResponse},
 };
-use axum_login::{AuthLayer, AuthUser, UserStore, axum_sessions::SessionLayer, secrecy::SecretVec};
+use axum_sessions::{PersistencePolicy, SameSite, SessionLayer};
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use serde::{Deserialize, Serialize};
 use shared::{GetUserInfo, UserInfo};
 use tracing::instrument;
 
 use crate::{env::admin_pwd_hash, error::InternalError};
 
+/// Cookie carrying the admin JWT. Verified statelessly on every request — no Redis lookup.
+const AUTH_COOKIE: &str = "auth";
+const ADMIN_NAME: &str = "admin";
+/// Token / cookie lifetime (was the session ttl).
+const COOKIE_TTL: Duration = Duration::from_secs(60 * 60 * 2);
+
+/// JWT signing key + cookie flags, shared via request extension so the handlers and the
+/// `OptionalUser` extractor can verify tokens without any session store.
+#[derive(Clone)]
+pub struct AuthConfig {
+    secret: Arc<[u8]>,
+    prod: bool,
+}
+
+impl AuthConfig {
+    fn new(secret: Vec<u8>, prod: bool) -> Self {
+        Self {
+            secret: secret.into(),
+            prod,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Claims {
+    /// token kind — `admin`; guards against a differently-scoped token being replayed here.
+    sub: String,
+    exp: u64,
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn validation() -> Validation {
+    let mut v = Validation::new(Algorithm::HS256);
+    // we don't use `aud`; default-on validation would otherwise reject our tokens
+    v.validate_aud = false;
+    v
+}
+
+fn issue_admin_token(cfg: &AuthConfig) -> Result<String, InternalError> {
+    let claims = Claims {
+        sub: ADMIN_NAME.to_string(),
+        exp: now_secs() + COOKIE_TTL.as_secs(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(cfg.secret.as_ref()),
+    )
+    .map_err(|e| InternalError::General(format!("jwt encode: {e}")))
+}
+
+fn verify_admin(cfg: &AuthConfig, token: &str) -> Option<AdminUser> {
+    let data = decode::<Claims>(
+        token,
+        &DecodingKey::from_secret(cfg.secret.as_ref()),
+        &validation(),
+    )
+    .ok()?;
+
+    (data.claims.sub == ADMIN_NAME).then(|| AdminUser {
+        name: data.claims.sub,
+        expires: Duration::from_secs(data.claims.exp.saturating_sub(now_secs())),
+    })
+}
+
+/// Read a single cookie value out of the `Cookie` request header.
+fn read_cookie<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers
+        .get(header::COOKIE)?
+        .to_str()
+        .ok()?
+        .split(';')
+        .filter_map(|kv| kv.split_once('='))
+        .find_map(|(k, v)| (k.trim() == name).then_some(v.trim()))
+}
+
+/// `Set-Cookie` value for `name`, expiring in `max_age` (zero clears it).
+fn set_cookie(cfg: &AuthConfig, name: &str, value: &str, max_age: Duration) -> String {
+    let same_site = if cfg.prod { "Strict" } else { "None" };
+    format!(
+        "{name}={value}; HttpOnly; Path=/; Max-Age={}; SameSite={same_site}; Secure",
+        max_age.as_secs()
+    )
+}
+
 #[derive(Debug, Clone)]
-pub struct User {
-    id: String,
-    password_hash: String,
+pub struct AdminUser {
+    name: String,
+    expires: Duration,
 }
 
-impl AuthUser<String> for User {
-    fn get_id(&self) -> String {
-        self.id.clone()
-    }
-
-    fn get_password_hash(&self) -> SecretVec<u8> {
-        SecretVec::new(self.password_hash.clone().into())
-    }
-}
-
-type AuthContext = axum_login::extractors::AuthContext<String, User, DumbAdminUserStore>;
-
-#[instrument(skip(auth), err)]
+#[instrument(skip_all, err)]
+#[allow(clippy::unused_async)]
 pub async fn login_handler(
-    mut auth: AuthContext,
+    Extension(cfg): Extension<AuthConfig>,
     Json(payload): Json<shared::UserLogin>,
 ) -> std::result::Result<impl IntoResponse, InternalError> {
-    let admin = admin_user();
-    if payload.name == admin.id && payload.pwd_hash == admin.password_hash {
+    let expected = admin_pwd_hash();
+
+    if !expected.is_empty() && payload.name == ADMIN_NAME && payload.pwd_hash == expected {
         tracing::info!("log in: {:?}", payload.name);
 
-        auth.login(&User {
-            id: String::from("admin"),
-            password_hash: admin_pwd_hash(),
-        })
-        .await?;
-
-        Ok(())
+        let token = issue_admin_token(&cfg)?;
+        Ok(AppendHeaders([(
+            header::SET_COOKIE,
+            set_cookie(&cfg, AUTH_COOKIE, &token, COOKIE_TTL),
+        )]))
     } else {
         Err(InternalError::InvalidLogin)
     }
 }
 
-fn admin_user() -> User {
-    User {
-        id: String::from("admin"),
-        password_hash: admin_pwd_hash(),
-    }
-}
-
-#[instrument(skip(auth))]
-pub async fn logout_handler(mut auth: AuthContext) {
-    tracing::info!("log out: {:?}", &auth.current_user);
-    auth.logout().await;
-}
-
-#[instrument(skip(session), err)]
+#[instrument(skip_all)]
 #[allow(clippy::unused_async)]
-pub async fn admin_user_handler(
-    session: axum_sessions::extractors::ReadableSession,
-    OptionalUser(user): OptionalUser,
-) -> std::result::Result<impl IntoResponse, InternalError> {
-    tracing::info!("[admin] user handler {user:?}");
-    Ok(Json(GetUserInfo {
-        user: user.map(|user| UserInfo {
-            name: user.id,
-            expires: session.expires_in().unwrap_or_default(),
-        }),
-    }))
+pub async fn logout_handler(Extension(cfg): Extension<AuthConfig>) -> impl IntoResponse {
+    tracing::info!("log out");
+    // clearing the cookie is all logout can do for a stateless token
+    AppendHeaders([(
+        header::SET_COOKIE,
+        set_cookie(&cfg, AUTH_COOKIE, "", Duration::ZERO),
+    )])
 }
 
-pub struct OptionalUser(pub Option<User>);
+#[instrument(skip_all)]
+#[allow(clippy::unused_async)]
+pub async fn admin_user_handler(OptionalUser(user): OptionalUser) -> impl IntoResponse {
+    tracing::info!("[admin] user handler {user:?}");
+    Json(GetUserInfo {
+        user: user.map(|user| UserInfo {
+            name: user.name,
+            expires: user.expires,
+        }),
+    })
+}
+
+/// `Some` iff the request carries a valid, unexpired admin JWT cookie.
+pub struct OptionalUser(pub Option<AdminUser>);
 
 #[async_trait]
 impl<S> FromRequestParts<S> for OptionalUser
 where
     S: Send + Sync,
 {
-    type Rejection = StatusCode;
+    type Rejection = std::convert::Infallible;
 
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let auth: AuthContext = AuthContext::from_request_parts(parts, state)
-            .await
-            .map_err(|_err| StatusCode::INTERNAL_SERVER_ERROR)?;
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let user = parts.extensions.get::<AuthConfig>().and_then(|cfg| {
+            read_cookie(&parts.headers, AUTH_COOKIE).and_then(|token| verify_admin(cfg, token))
+        });
 
-        Ok(Self(auth.current_user))
+        Ok(Self(user))
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct DumbAdminUserStore;
-
-#[async_trait]
-impl<Role> UserStore<String, Role> for DumbAdminUserStore
-where
-    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
-    User: AuthUser<String, Role>,
-{
-    type User = User;
-
-    type Error = std::convert::Infallible;
-
-    async fn load_user(
-        &self,
-        user_id: &String,
-    ) -> std::result::Result<Option<Self::User>, Self::Error> {
-        tracing::debug!("load_user: {}", user_id);
-
-        let admin = admin_user();
-        if user_id == &admin.id {
-            Ok(Some(admin))
-        } else {
-            Ok(None)
-        }
-    }
-}
-
-//Note: session livetime
-const COOKIE_TTL: std::time::Duration = std::time::Duration::from_secs(60 * 60 * 2);
-
+/// Builds the pwd-session layer (still Redis-backed) and the stateless JWT config.
 pub fn setup(
-    secret: &[u8],
+    secret: Vec<u8>,
     session_store: RedisSessionStore,
     is_prod: bool,
-) -> (
-    SessionLayer<RedisSessionStore>,
-    AuthLayer<DumbAdminUserStore, String, User>,
-) {
+) -> (SessionLayer<RedisSessionStore>, AuthConfig) {
     let same_site_policy = if is_prod {
-        axum_sessions::SameSite::Strict
+        SameSite::Strict
     } else {
-        axum_sessions::SameSite::None
+        SameSite::None
     };
-    let session_layer = SessionLayer::new(session_store, secret)
+    let session_layer = SessionLayer::new(session_store, &secret)
         .with_cookie_name("sid")
-        .with_persistence_policy(axum_login::axum_sessions::PersistencePolicy::ExistingOnly)
+        .with_persistence_policy(PersistencePolicy::ExistingOnly)
         .with_same_site_policy(same_site_policy)
         .with_session_ttl(Some(COOKIE_TTL));
 
-    let auth_layer = AuthLayer::new(DumbAdminUserStore {}, secret);
-
-    (session_layer, auth_layer)
+    (session_layer, AuthConfig::new(secret, is_prod))
 }
 
 #[cfg(test)]
 pub fn setup_test() -> (
-    SessionLayer<axum_login::axum_sessions::async_session::MemoryStore>,
-    AuthLayer<DumbAdminUserStore, String, User>,
+    SessionLayer<axum_sessions::async_session::MemoryStore>,
+    AuthConfig,
 ) {
-    let secret = "0123456789012345678901234567890123456789012345678901234567890123";
-    let session_store = axum_login::axum_sessions::async_session::MemoryStore::new();
-    let session_layer = SessionLayer::new(session_store, secret.as_bytes())
+    let secret = b"0123456789012345678901234567890123456789012345678901234567890123".to_vec();
+    let session_store = axum_sessions::async_session::MemoryStore::new();
+    let session_layer = SessionLayer::new(session_store, &secret)
         .with_cookie_name("sid")
-        .with_persistence_policy(axum_login::axum_sessions::PersistencePolicy::ExistingOnly)
+        .with_persistence_policy(PersistencePolicy::ExistingOnly)
         .with_session_ttl(Some(COOKIE_TTL));
 
-    let auth_layer = AuthLayer::new(DumbAdminUserStore {}, secret.as_bytes());
+    (session_layer, AuthConfig::new(secret, false))
+}
 
-    (session_layer, auth_layer)
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn cfg() -> AuthConfig {
+        AuthConfig::new(
+            b"0123456789012345678901234567890123456789012345678901234567890123".to_vec(),
+            false,
+        )
+    }
+
+    fn sign(cfg: &AuthConfig, claims: &Claims) -> String {
+        encode(
+            &Header::default(),
+            claims,
+            &EncodingKey::from_secret(cfg.secret.as_ref()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn admin_token_roundtrips() {
+        let cfg = cfg();
+        let user = verify_admin(&cfg, &issue_admin_token(&cfg).unwrap()).expect("valid token");
+        assert_eq!(user.name, ADMIN_NAME);
+        assert!(user.expires <= COOKIE_TTL && user.expires.as_secs() + 5 > COOKIE_TTL.as_secs());
+    }
+
+    #[test]
+    fn rejects_token_signed_with_other_secret() {
+        let token = issue_admin_token(&cfg()).unwrap();
+        let other = AuthConfig::new(
+            b"9999999999999999999999999999999999999999999999999999999999999999".to_vec(),
+            false,
+        );
+        assert!(verify_admin(&other, &token).is_none());
+    }
+
+    #[test]
+    fn rejects_non_admin_subject() {
+        // a validly-signed token whose subject isn't the admin (e.g. a future pwd grant) must
+        // never authenticate as admin
+        let cfg = cfg();
+        let token = sign(
+            &cfg,
+            &Claims {
+                sub: "pwd".to_string(),
+                exp: now_secs() + 60,
+            },
+        );
+        assert!(verify_admin(&cfg, &token).is_none());
+    }
+
+    #[test]
+    fn rejects_expired_token() {
+        let cfg = cfg();
+        let token = sign(
+            &cfg,
+            &Claims {
+                sub: ADMIN_NAME.to_string(),
+                exp: now_secs().saturating_sub(3600),
+            },
+        );
+        assert!(verify_admin(&cfg, &token).is_none());
+    }
+
+    #[test]
+    fn reads_named_cookie_among_many() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            "foo=1; auth=the-token; bar=2".parse().unwrap(),
+        );
+        assert_eq!(read_cookie(&headers, AUTH_COOKIE), Some("the-token"));
+        assert_eq!(read_cookie(&headers, "missing"), None);
+    }
 }

--- a/backend/src/env.rs
+++ b/backend/src/env.rs
@@ -17,13 +17,36 @@ pub fn admin_pwd_hash() -> String {
     std::env::var(ENV_ADMIN_PWD_HASH).unwrap_or_default()
 }
 
+/// Insecure well-known fallback used only for local dev / tests when `LA_SESSION_SECRET`
+/// is unset. Since auth is now a stateless JWT, this key MUST NOT be used in production —
+/// anyone who reads the repo could otherwise forge an admin token (see [`is_default_session_secret`]).
+const DEFAULT_DEV_SECRET: &str = "0123456789012345678901234567890123456789012345678901234567890123";
+
 pub fn session_secret() -> Option<Vec<u8>> {
     let vec: Vec<_> = std::env::var(ENV_SESSION_SECRET)
-        .unwrap_or_else(|_| {
-            String::from("0123456789012345678901234567890123456789012345678901234567890123")
-        })
+        .unwrap_or_else(|_| String::from(DEFAULT_DEV_SECRET))
         .as_bytes()
         .into();
 
     (vec.len() >= 64).then_some(vec)
+}
+
+/// Whether `secret` is the built-in dev fallback; the caller refuses to start with it in prod.
+pub fn is_default_session_secret(secret: &[u8]) -> bool {
+    secret == DEFAULT_DEV_SECRET.as_bytes()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn dev_fallback_is_recognised_and_long_enough() {
+        // the fallback must pass the >=64 gate (otherwise session_secret would reject it in dev)
+        assert!(DEFAULT_DEV_SECRET.len() >= 64);
+        assert!(is_default_session_secret(DEFAULT_DEV_SECRET.as_bytes()));
+        assert!(!is_default_session_secret(
+            b"some other 64+ byte secret ................................"
+        ));
+    }
 }

--- a/backend/src/handle.rs
+++ b/backend/src/handle.rs
@@ -327,7 +327,7 @@ mod test_db_item_not_found {
     };
     use async_trait::async_trait;
     use axum::{
-        Router,
+        Extension, Router,
         body::Body,
         http::{self, Request, StatusCode},
         routing::{get, post},
@@ -369,8 +369,8 @@ mod test_db_item_not_found {
 
             Router::new()
                 .route("/api/event/:id", get(getevent_handler))
-                .layer(auth)
                 .layer(session)
+                .layer(Extension(auth))
                 .layer(TraceLayer::new_for_http())
                 .with_state(app.clone())
         };
@@ -406,8 +406,8 @@ mod test_db_item_not_found {
             let (session, auth) = auth::setup_test();
             let router = Router::new()
                 .route("/api/event/:id", get(getevent_handler))
-                .layer(auth)
                 .layer(session)
+                .layer(Extension(auth))
                 .layer(TraceLayer::new_for_http())
                 .with_state(app.clone());
             (app, router)
@@ -459,8 +459,8 @@ mod test_db_item_not_found {
             let router = Router::new()
                 .route("/api/event/:id", get(getevent_handler))
                 .route("/api/event/:id/pwd", post(set_event_password))
-                .layer(auth)
                 .layer(session)
+                .layer(Extension(auth))
                 .layer(TraceLayer::new_for_http())
                 .with_state(app.clone());
             (app, router)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -267,6 +267,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let secret = session_secret()
         .ok_or_else(|| error::InternalError::General(String::from("invalid session secret")))?;
 
+    // auth is now a stateless JWT: knowing the signing key is enough to forge an admin token,
+    // so refuse to start in prod with the public dev fallback.
+    if is_prod() && env::is_default_session_secret(&secret) {
+        return Err("LA_SESSION_SECRET must be set to a non-default value in production".into());
+    }
+
     let (session_layer, auth_config) = auth::setup(
         secret,
         RedisSessionStore::new(redis_url)?.with_prefix("session/"),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -22,7 +22,7 @@ use async_redis_session::RedisSessionStore;
 use aws_config::BehaviorVersion;
 use aws_sdk_dynamodb::config::Credentials;
 use axum::{
-    Router,
+    Extension, Router,
     http::header,
     routing::{get, post},
 };
@@ -267,8 +267,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let secret = session_secret()
         .ok_or_else(|| error::InternalError::General(String::from("invalid session secret")))?;
 
-    let (session_layer, auth_layer) = auth::setup(
-        secret.as_ref(),
+    let (session_layer, auth_config) = auth::setup(
+        secret,
         RedisSessionStore::new(redis_url)?.with_prefix("session/"),
         is_prod(),
     );
@@ -311,7 +311,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .nest("/api/mod/event", mod_routes)
         .nest("/api/admin", admin_routes)
         .route("/metrics", get(async move || metrics_handler.render()))
-        .layer(auth_layer)
+        .layer(Extension(auth_config))
         .layer(session_layer)
         .layer(SetSensitiveRequestHeadersLayer::new(once(header::COOKIE)))
         .layer(SentryHttpLayer::with_transaction())


### PR DESCRIPTION
Admin login now issues an HS256 JWT (reusing LA_SESSION_SECRET) delivered
as an HttpOnly cookie, verified statelessly on each request instead of
loading a session from Redis. Drops axum-login and the DumbAdminUserStore.

The event-password feature still uses the redis-backed session for now;
that is removed in a follow-up so the session layer can be deleted entirely.