### PR TITLE
backend: harden stripe webhook processing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -118,6 +118,10 @@ jobs:
           RUST_LOG: warn,liveask_server=info
           URL: http://localhost:8090
           SOCKET_URL: ws://localhost:8090
+          # test-only value so the webhook signature-verification path is actually
+          # exercised (test_stripe_webhook_bad_signature_rejected). The server now fails
+          # closed when this is empty, which would otherwise 500 before the signature check.
+          LA_STRIPE_HOOK_SECRET: whsec_e2e_test_secret_do_not_use
         run: |
           ./target/debug/liveask-server > server.log 2>&1 &
           trap 'kill $! 2>/dev/null || true' EXIT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+* stripe webhook hardening [#118](https://github.com/liveask/liveask/pull/118)
+
 ## [2.15.0] - 2026-07-08
 
 ### Changed

--- a/backend/src/payment/mod.rs
+++ b/backend/src/payment/mod.rs
@@ -333,26 +333,43 @@ impl Payment {
 
         let sess = CheckoutSession::retrieve(&self.client, &sess, &[]).await?;
 
+        let completed = Self::checkout_is_paid(&sess);
         let event = sess.client_reference_id.unwrap_or_default();
-        // require both a completed session AND cleared payment; a completed session can
-        // still be `Unpaid` for async payment methods, which must not capture as premium
-        let completed = sess
-            .status
+
+        Ok((event, completed))
+    }
+
+    // require both a completed session AND cleared payment; a completed session can
+    // still be `Unpaid` for async payment methods, which must not capture as premium
+    fn checkout_is_paid(sess: &CheckoutSession) -> bool {
+        sess.status
             .is_some_and(|status| status == CheckoutSessionStatus::Complete)
             && matches!(
                 sess.payment_status,
                 CheckoutSessionPaymentStatus::Paid
                     | CheckoutSessionPaymentStatus::NoPaymentRequired
-            );
-
-        Ok((event, completed))
+            )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::Payment;
-    use stripe::{CheckoutSession, PaymentPagesCheckoutSessionCustomerDetails};
+    use stripe::{
+        CheckoutSession, CheckoutSessionPaymentStatus, CheckoutSessionStatus,
+        PaymentPagesCheckoutSessionCustomerDetails,
+    };
+
+    fn session(
+        status: Option<CheckoutSessionStatus>,
+        payment_status: CheckoutSessionPaymentStatus,
+    ) -> CheckoutSession {
+        CheckoutSession {
+            status,
+            payment_status,
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn checkout_email_prefers_customer_details() {
@@ -382,5 +399,40 @@ mod tests {
             Payment::checkout_email(&session),
             Some("fallback@example.com")
         );
+    }
+
+    #[test]
+    fn checkout_is_paid_requires_complete_and_cleared() {
+        assert!(Payment::checkout_is_paid(&session(
+            Some(CheckoutSessionStatus::Complete),
+            CheckoutSessionPaymentStatus::Paid,
+        )));
+        // free upgrades legitimately need no payment
+        assert!(Payment::checkout_is_paid(&session(
+            Some(CheckoutSessionStatus::Complete),
+            CheckoutSessionPaymentStatus::NoPaymentRequired,
+        )));
+    }
+
+    #[test]
+    fn checkout_is_paid_rejects_completed_but_unpaid() {
+        // the regression this branch guards: async payment methods can complete a
+        // session while the money is still `Unpaid` — must not capture as premium
+        assert!(!Payment::checkout_is_paid(&session(
+            Some(CheckoutSessionStatus::Complete),
+            CheckoutSessionPaymentStatus::Unpaid,
+        )));
+    }
+
+    #[test]
+    fn checkout_is_paid_rejects_incomplete_session() {
+        assert!(!Payment::checkout_is_paid(&session(
+            None,
+            CheckoutSessionPaymentStatus::Paid,
+        )));
+        assert!(!Payment::checkout_is_paid(&session(
+            Some(CheckoutSessionStatus::Open),
+            CheckoutSessionPaymentStatus::Paid,
+        )));
     }
 }

--- a/backend/src/payment/mod.rs
+++ b/backend/src/payment/mod.rs
@@ -4,10 +4,10 @@ use futures_util::TryStreamExt;
 use std::str::FromStr;
 use stripe::{
     BillingPortalSession, CheckoutSession, CheckoutSessionId, CheckoutSessionMode,
-    CheckoutSessionStatus, Client, CreateBillingPortalSession, CreateCheckoutSession,
-    CreateCheckoutSessionLineItems, CreateCheckoutSessionPaymentIntentData, Customer, CustomerId,
-    ListCustomers, ListPaymentLinks, ListProducts, ListSubscriptions, PaymentLink, Subscription,
-    SubscriptionStatus,
+    CheckoutSessionPaymentStatus, CheckoutSessionStatus, Client, CreateBillingPortalSession,
+    CreateCheckoutSession, CreateCheckoutSessionLineItems, CreateCheckoutSessionPaymentIntentData,
+    Customer, CustomerId, ListCustomers, ListPaymentLinks, ListProducts, ListSubscriptions,
+    PaymentLink, Subscription, SubscriptionStatus,
 };
 use tracing::instrument;
 
@@ -334,9 +334,16 @@ impl Payment {
         let sess = CheckoutSession::retrieve(&self.client, &sess, &[]).await?;
 
         let event = sess.client_reference_id.unwrap_or_default();
+        // require both a completed session AND cleared payment; a completed session can
+        // still be `Unpaid` for async payment methods, which must not capture as premium
         let completed = sess
             .status
-            .is_some_and(|status| status == CheckoutSessionStatus::Complete);
+            .is_some_and(|status| status == CheckoutSessionStatus::Complete)
+            && matches!(
+                sess.payment_status,
+                CheckoutSessionPaymentStatus::Paid
+                    | CheckoutSessionPaymentStatus::NoPaymentRequired
+            );
 
         Ok((event, completed))
     }

--- a/backend/src/stripe_webhooks.rs
+++ b/backend/src/stripe_webhooks.rs
@@ -4,7 +4,7 @@ use axum::{
     response::{Html, IntoResponse, Response},
 };
 use reqwest::StatusCode;
-use stripe::{Event, EventObject, EventType};
+use stripe::{CheckoutSessionPaymentStatus, Event, EventObject, EventType};
 
 use crate::{app::SharedApp, env, error::InternalError};
 
@@ -33,6 +33,13 @@ where
         //TODO: do not read env everytime
         let secret = std::env::var(env::ENV_STRIPE_HOOK_SECRET).unwrap_or_default();
 
+        // Fail closed: an empty signing secret makes the webhook HMAC publicly computable,
+        // so anyone could forge a paid checkout. Never verify against an empty key.
+        if secret.is_empty() {
+            tracing::error!("stripe webhook secret not configured; rejecting webhook");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+        }
+
         Ok(Self(
             stripe::Webhook::construct_event(
                 &payload,
@@ -53,12 +60,29 @@ pub async fn handle_webhook(
     match event.type_ {
         EventType::CheckoutSessionCompleted => {
             if let EventObject::CheckoutSession(session) = event.data.object {
-                tracing::info!("[hooks] CheckoutSessionCompleted: {:?}", session.id);
+                tracing::info!(
+                    "[hooks] CheckoutSessionCompleted: {:?} (payment_status: {:?})",
+                    session.id,
+                    session.payment_status
+                );
 
-                if let Some(event) = session.client_reference_id {
-                    if let Err(e) = app.payment_webhook(session.id.to_string(), event).await {
-                        tracing::error!("[hooks] failed: {e}");
+                // a completed session can still be `Unpaid` for async/delayed payment
+                // methods; only fulfil once Stripe reports the money actually cleared
+                if matches!(
+                    session.payment_status,
+                    CheckoutSessionPaymentStatus::Paid
+                        | CheckoutSessionPaymentStatus::NoPaymentRequired
+                ) {
+                    if let Some(event) = session.client_reference_id {
+                        // propagate so a transient failure returns 5xx and Stripe retries,
+                        // instead of silently dropping an upgrade the customer paid for
+                        app.payment_webhook(session.id.to_string(), event).await?;
                     }
+                } else {
+                    tracing::warn!(
+                        "[hooks] checkout completed but not paid ({:?}); skipping upgrade",
+                        session.payment_status
+                    );
                 }
             }
         }


### PR DESCRIPTION
- fail closed when LA_STRIPE_HOOK_SECRET is unset: an empty signing key makes the webhook HMAC publicly computable, so a forged checkout could grant free premium. Reject the request instead of verifying with .
- return 5xx (propagate the error) when payment_webhook fails so Stripe retries delivery, instead of swallowing it and returning 200 -- a transient DB error would otherwise permanently drop a paid upgrade.
- only fulfil on payment_status Paid/NoPaymentRequired; a completed checkout session can still be Unpaid for async payment methods. Applied to both the webhook and the premium_capture path (retrieve_event_state).