### PR TITLE
shared/frontend: reject non-http(s) context link URLs (stored XSS)

### DIFF
--- a/frontend/src/components/context_popup.rs
+++ b/frontend/src/components/context_popup.rs
@@ -245,6 +245,9 @@ impl ContextPopup {
             ValidationState::Invalid(ContextUrlError::Invalid(_)) => {
                 Some("Invalid URL".to_string())
             }
+            ValidationState::Invalid(ContextUrlError::DisallowedScheme) => {
+                Some("Only http/https links are allowed".to_string())
+            }
             _ => None,
         }
     }

--- a/frontend/src/components/event_context.rs
+++ b/frontend/src/components/event_context.rs
@@ -59,7 +59,7 @@ impl Component for EventContext {
 impl EventContext {
     fn view_item(item: &ContextItem) -> Html {
         html! {
-            <a class="item" href={item.url.clone()} target="_blank">
+            <a class="item" href={item.url.clone()} target="_blank" rel="noopener noreferrer">
                 <img src="assets/context.svg" />
                 <div class="label">{ item.label.clone() }</div>
             </a>

--- a/shared/src/validation/context_validation.rs
+++ b/shared/src/validation/context_validation.rs
@@ -9,6 +9,9 @@ pub enum ContextLabelError {
 #[derive(Debug)]
 pub enum ContextUrlError {
     Invalid(url::ParseError),
+    /// scheme other than http/https (e.g. `javascript:`, `data:`) — refused because the
+    /// url is rendered as a clickable link for every event viewer.
+    DisallowedScheme,
 }
 
 const LABEL_TRIMMED_MIN_LEN: usize = 4;
@@ -47,7 +50,40 @@ impl ContextValidation {
     fn check_url(v: &str) -> ValidationState<ContextUrlError> {
         match url::Url::parse(v) {
             Err(e) => ValidationState::Invalid(ContextUrlError::Invalid(e)),
+            // only http(s) may be stored: the url becomes a clickable href for every event
+            // viewer, so `javascript:`/`data:`/etc. would be a stored-XSS vector
+            Ok(url) if !matches!(url.scheme(), "http" | "https") => {
+                ValidationState::Invalid(ContextUrlError::DisallowedScheme)
+            }
             Ok(_) => ValidationState::Valid,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn valid(v: &str) -> bool {
+        ContextValidation::check_url(v).is_valid()
+    }
+
+    #[test]
+    fn accepts_http_and_https() {
+        assert!(valid("https://example.com"));
+        assert!(valid("http://example.com/path?q=1"));
+    }
+
+    #[test]
+    fn rejects_dangerous_schemes() {
+        assert!(!valid("javascript:alert(1)"));
+        assert!(!valid("data:text/html,<script>alert(1)</script>"));
+        assert!(!valid("vbscript:msgbox(1)"));
+        assert!(!valid("file:///etc/passwd"));
+    }
+
+    #[test]
+    fn rejects_unparseable() {
+        assert!(!valid("not a url"));
     }
 }


### PR DESCRIPTION
check_url accepted any scheme url::Url::parse could handle, incl. javascript:/data:/vbscript:/file:. The context link is stored verbatim and rendered as a clickable `<a href>` for every event viewer, so a premium moderator could set a javascript: url that runs in every visitor's browser. Restrict check_url to http/https (enforced server side via ContextValidation), show a clear message in the mod popup, and add rel=noopener noreferrer to the rendered link.