### PR TITLE
backend: keep passwords and PII off tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * stripe webhook hardening [#118](https://github.com/liveask/liveask/pull/118)
 * hardening context url [#119](https://github.com/liveask/liveask/pull/119)
+* keep passwords and PII out of tracing spans [#120](https://github.com/liveask/liveask/pull/120)
 
 ## [2.15.0] - 2026-07-08
 

--- a/backend/src/handle.rs
+++ b/backend/src/handle.rs
@@ -40,7 +40,9 @@ pub async fn editlike_handler(
     Ok(Json(app.edit_like(id, payload).await?))
 }
 
-#[instrument(skip(app))]
+// skip(payload): AddEvent carries the moderator's email (PII); #[instrument] would
+// otherwise record it as a span field and ship it to logs/Sentry
+#[instrument(skip(app, payload))]
 pub async fn addevent_handler(
     State(app): State<SharedApp>,
     Json(payload): Json<shared::AddEvent>,
@@ -78,7 +80,9 @@ pub async fn getevent_handler(
     ))
 }
 
-#[instrument(skip(app, cfg))]
+// skip(payload): the request carries the cleartext event password; #[instrument] would
+// otherwise record it as a span field and ship it to logs/Sentry (cf. login_handler)
+#[instrument(skip(app, cfg, payload))]
 pub async fn set_event_password(
     Path(id): Path<String>,
     Extension(cfg): Extension<AuthConfig>,
@@ -198,7 +202,9 @@ pub async fn mod_edit_event(
     Ok(Json(app.mod_edit_event(id, secret, payload).await?))
 }
 
-#[instrument(skip(app))]
+// skip(payload): SubscriptionCheckout can carry the customer's email (PII); keep it off
+// the span so it never reaches logs/Sentry
+#[instrument(skip(app, payload))]
 pub async fn subscription_handler(
     State(app): State<SharedApp>,
     Json(payload): Json<shared::SubscriptionCheckout>,


### PR DESCRIPTION
#[instrument] auto-records every non-skipped argument as a span field (via Debug), which flows to logs and Sentry. Three handlers leaked sensitive payloads:
- set_event_password: cleartext event password
- addevent_handler: moderator email
- subscription_handler: customer email

Add these payloads to their skip lists, matching login_handler's skip_all pattern.