### PR TITLE
backend: ignore RELAX_CORS in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * stripe webhook hardening [#118](https://github.com/liveask/liveask/pull/118)
 * hardening context url [#119](https://github.com/liveask/liveask/pull/119)
 * keep passwords and PII out of tracing spans [#120](https://github.com/liveask/liveask/pull/120)
+* refuse relaxed CORS in production [#121](https://github.com/liveask/liveask/pull/121)
 
 ## [2.15.0] - 2026-07-08
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -88,7 +88,14 @@ fn is_prod() -> bool {
 }
 
 fn use_relaxed_cors() -> bool {
-    std::env::var(env::ENV_RELAX_CORS).is_ok_and(|var| var == "1")
+    let relaxed = std::env::var(env::ENV_RELAX_CORS).is_ok_and(|var| var == "1");
+    // relaxed CORS mirrors any origin AND allows credentials; never permit that in prod,
+    // regardless of RELAX_CORS, so a stray env var cannot open production up
+    if relaxed && is_prod() {
+        tracing::warn!("RELAX_CORS is ignored in production");
+        return false;
+    }
+    relaxed
 }
 
 fn get_port() -> u16 {


### PR DESCRIPTION
use_relaxed_cors enabled a very-permissive CORS layer (mirrors any origin + allow_credentials) whenever RELAX_CORS=1, with no prod guard -- so a stray env var could open production up to credentialed cross-origin requests. Refuse relaxed CORS in prod regardless of the flag, mirroring the existing session-secret prod guard.