### PR TITLE
backend: harden auth for all public envs, not just prod=="prod"

### DIFF
--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -29,14 +29,15 @@ const COOKIE_TTL: Duration = Duration::from_secs(2 * 60 * 60);
 #[derive(Clone)]
 pub struct AuthConfig {
     secret: Arc<[u8]>,
-    prod: bool,
+    /// harden cookies (SameSite=Strict) — true on every public deployment, not just prod.
+    secure: bool,
 }
 
 impl AuthConfig {
-    fn new(secret: Vec<u8>, prod: bool) -> Self {
+    fn new(secret: Vec<u8>, secure: bool) -> Self {
         Self {
             secret: secret.into(),
-            prod,
+            secure,
         }
     }
 }
@@ -145,7 +146,7 @@ fn read_cookie<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
 
 /// `Set-Cookie` value for `name`, expiring in `max_age` (zero clears it).
 fn set_cookie(cfg: &AuthConfig, name: &str, value: &str, max_age: Duration) -> String {
-    let same_site = if cfg.prod { "Strict" } else { "None" };
+    let same_site = if cfg.secure { "Strict" } else { "None" };
     format!(
         "{name}={value}; HttpOnly; Path=/; Max-Age={}; SameSite={same_site}; Secure",
         max_age.as_secs()
@@ -221,9 +222,10 @@ where
     }
 }
 
-/// Stateless JWT config shared into the router as a request extension.
-pub fn setup(secret: Vec<u8>, is_prod: bool) -> AuthConfig {
-    AuthConfig::new(secret, is_prod)
+/// Stateless JWT config shared into the router as a request extension. `secure` hardens
+/// cookies (SameSite=Strict) and is set for every public (non-local) deployment.
+pub fn setup(secret: Vec<u8>, secure: bool) -> AuthConfig {
+    AuthConfig::new(secret, secure)
 }
 
 #[cfg(test)]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -87,6 +87,12 @@ fn is_prod() -> bool {
     production_env() == "prod"
 }
 
+/// Whether we run the local dev/test environment. Any other `LIVEASK_ENV` (prod, beta, ...)
+/// is a publicly reachable deployment that must be hardened.
+fn is_local() -> bool {
+    production_env() == "local"
+}
+
 fn use_relaxed_cors() -> bool {
     let relaxed = std::env::var(env::ENV_RELAX_CORS).is_ok_and(|var| var == "1");
     // relaxed CORS mirrors any origin AND allows credentials; never permit that in prod,
@@ -274,12 +280,15 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .ok_or_else(|| error::InternalError::General(String::from("invalid session secret")))?;
 
     // auth is now a stateless JWT: knowing the signing key is enough to forge an admin token,
-    // so refuse to start in prod with the public dev fallback.
-    if is_prod() && env::is_default_session_secret(&secret) {
-        return Err("LA_SESSION_SECRET must be set to a non-default value in production".into());
+    // so refuse to start on any public (non-local) env with the well-known dev fallback.
+    if !is_local() && env::is_default_session_secret(&secret) {
+        return Err(
+            "LA_SESSION_SECRET must be set to a non-default value outside local dev".into(),
+        );
     }
 
-    let auth_config = auth::setup(secret, is_prod());
+    // harden cookies (SameSite=Strict) on every public env, not just prod
+    let auth_config = auth::setup(secret, !is_local());
 
     let admin_routes = Router::new()
         .route("/user", get(admin_user_handler))


### PR DESCRIPTION
Since auth is a stateless JWT, the signing key alone forges an admin token. Two hardening steps were keyed to LIVEASK_ENV=="prod", leaving the public beta deployment (non-"prod" env) exposed:
- the guard refusing to boot on the committed DEFAULT_DEV_SECRET
- SameSite=Strict cookies (beta got SameSite=None)

Gate both on !is_local() instead so every public deployment is protected. Rename AuthConfig.prod -> secure to reflect the broader meaning.